### PR TITLE
Allow input to accept a string or a number

### DIFF
--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -130,7 +130,7 @@ export default class Input extends Component {
     /**
      * The input value, required for a controlled component.
      */
-    value: PropTypes.string,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   };
 
   static defaultProps = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->
This allows the Input component to except a string or a number for its value prop.

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

